### PR TITLE
Update trltevzw fingerprint and build.description

### DIFF
--- a/init/init_trlte.cpp
+++ b/init/init_trlte.cpp
@@ -157,13 +157,13 @@ void vendor_load_properties()
     } else if (bootloader.find("N910V") == 0) {
         /* trltevzw */
         for (const auto &source : ro_product_props_default_source_order) {
-            set_ro_product_prop(source, "fingerprint", "Verizon/trltevzw/trltevzw:6.0.1/MMB29M/N910VVRU2CQL1:user/release-keys");
+            set_ro_product_prop(source, "fingerprint", "Verizon/trltevzw/trltevzw:6.0.1/MMB29M/N910VVRU2CTI1:user/release-keys");
             set_ro_product_prop(source, "model", "SM-N910V");
             set_ro_product_prop(source, "device", "trltevzw");
             set_ro_product_prop(source, "name", "trltevzw");
         }
         SetProperty("ro.telephony.get_imsi_from_sim", "true");
-        property_override("ro.build.description", "trltevzw-user 6.0.1 MMB29M N910VVRU2CQL1 release-keys");
+        property_override("ro.build.description", "trltevzw-user 6.0.1 MMB29M N910VVRU2CTI1 release-keys");
         cdma_properties("Verizon", "311480", "1");
     } else if (bootloader.find("N910W8") == 0) {
         /* trltecan */


### PR DESCRIPTION
If needed, here's a link to the modem.tar file for N910VVRU2CTI1:

https://mega.nz/file/O54g2ZbK#ytGj--W5BCJy7Wx0PDKYG92AXVnrmoxL_xRpNsG90Zs

It flashed fine for me using Linux OS and Jodin to flash the firmware, but a couple Windows users needed to remove the .md5 from file name. Change CTI1_Modem.tar.md5 to CTI1_Modem.tar then flash with Odin

@ripee  
I thought you might already have a CTI1 modem file in your trlte LineageOS 18.1 thread and didn't want anyone thinking it was another update.